### PR TITLE
Update 02.2022.1 - Definitions

### DIFF
--- a/documents/motions/02.2022.1 - Definitions.md
+++ b/documents/motions/02.2022.1 - Definitions.md
@@ -52,7 +52,7 @@ Within WCA we use the following definitions for terminology.
     </tr>
     <tr>
       <td>Community</td>
-      <td>The Community of the WCA as formed by all WCA Staff, Registered Speedcubers, and Partners.</td>
+      <td>The Community of the WCA as formed by all Staff, Registered Speedcubers, Partners, Spectators, and Users of official WCA online services.</td>
     </tr>
     <tr>
       <td>Competition Organizer</td>

--- a/documents/motions/02.2022.1 - Definitions.md
+++ b/documents/motions/02.2022.1 - Definitions.md
@@ -1,10 +1,10 @@
 # SUBMISSION OF PROPOSED MOTION
 
-**Motion number:** 2.2022.1  
+**Motion number:** 2.2024.1  
 **Subject:** Definitions  
 **Intent:** Define WCA terminology  
 **Submitted by:** WCA Board  
-**Date:** May 1, 2022
+**Date:** TBC, 2024
 
 # Motion
 
@@ -32,11 +32,11 @@ Within WCA we use the following definitions for terminology.
     </tr>
     <tr>
       <td>Code of Ethics</td>
-      <td>The code of the WCA containing principles of ethical conduct.</td>
+      <td>The code of the WCA containing principles of conduct for WCA Staff.</td>
     </tr>
     <tr>
       <td>Committee/Team</td>
-      <td>A Committee/Team of the WCA that has been appointed by the WCA under the terms of the WCA Bylaws or any of the Motions. Leaders of Committees/Teams are WCA Staff with Voting Rights and rest of Committees/Teams members are WCA Staff without Voting Rights.</td>
+      <td>A Committee/Team of the WCA that has been appointed by the WCA under the terms of the WCA Bylaws or any of the Motions. Leaders and Senior Members of Committees/Teams are WCA Staff with Voting Rights and the rest of Committees/Teams members are WCA Staff without Voting Rights.</td>
     </tr>
     <tr>
       <td>Committee/Team Leader</td>
@@ -52,15 +52,11 @@ Within WCA we use the following definitions for terminology.
     </tr>
     <tr>
       <td>Community</td>
-      <td>The Community of the WCA as formed by all Staff, Registered Speedcubers, and Partners.</td>
+      <td>The Community of the WCA as formed by all WCA Staff, Registered Speedcubers, and Partners.</td>
     </tr>
     <tr>
       <td>Competition Organizer</td>
-      <td>Persons who are responsible for the organization of a WCA Competition, as defined in the WCA Regulations.</td>
-    </tr>
-    <tr>
-      <td>Competition Staff</td>
-      <td>Persons who are responsible for the operational procedures during a WCA Competition, as defined in the WCA Regulations.</td>
+      <td>Persons who are responsible for the organization of a WCA Competition, as defined in the WCA Regulations and WCA Competition Requirements Policy.</td>
     </tr>
     <tr>
       <td>Competitor</td>
@@ -84,7 +80,7 @@ Within WCA we use the following definitions for terminology.
     </tr>
     <tr>
       <td>Country</td>
-      <td>A self-governing geographical area of the world recognized as an independent state by international law and international governmental bodies. <br> The Regulations contain the accepted list of countries.</td>
+      <td>Any country, state, territory or a part of territory recognised by the international community, in conformity with the Olympic Charter and the IOC regulations. <br> The Regulations contain the accepted list of countries.</td>
     </tr>
     <tr>
       <td>Event</td>
@@ -137,13 +133,12 @@ Within WCA we use the following definitions for terminology.
         <ul>
           <li>Sponsor</li>
           <li>Competition Organizer</li>
-          <li>Competition Staff</li>
         </ul>
       </td>
     </tr>
     <tr>
       <td>Policy</td>
-      <td>A set of rules or ideas proposed by the WCA Board that either help, guide, or regulate the Community.</td>
+      <td>A set of rules or ideas approved by the WCA Board that either help, guide, or regulate the Community.</td>
     </tr>
     <tr>
       <td>Regional Delegate</td>
@@ -168,23 +163,6 @@ Within WCA we use the following definitions for terminology.
     <tr>
       <td>Speedcubing</td>
       <td>The sport of solving twisty puzzles.</td>
-    </tr>
-    <tr>
-      <td>Staff</td>
-      <td>
-        <p>An appointed Staff Member of the WCA.</p>
-        <ul>
-          <li>Director</li>
-          <li>Officer</li>
-          <li>Committee/Team Leader</li>
-          <li>Committee/Team Senior Member</li>
-          <li>Committee/Team Member</li>
-          <li>Senior Delegate</li>
-          <li>Regional Delegate</li>
-          <li>Full Delegate</li>
-          <li>Junior Delegate</li>
-        </ul>
-      </td>
     </tr>
     <tr>
       <td>Supermajority</td>
@@ -224,11 +202,28 @@ Within WCA we use the following definitions for terminology.
     </tr>
     <tr>
       <td>WCA Competition</td>
-      <td>A competition acknowledged by the WCA Board, regulated by the Regulations, and overseen by a WCA Delegate.</td>
+      <td>A competition acknowledged by the WCA, regulated by the Regulations, and overseen by a WCA Delegate.</td>
     </tr>
     <tr>
       <td>WCA Delegate</td>
-      <td>A role defined in the Motions and in the WCA Regulations to oversee official WCA Competitions on behalf of the WCA.</td>
+      <td>A role defined in the Motions, the WCA Regulations and in the WCA Competition Requirements Policy to oversee official WCA Competitions on behalf of the WCA.</td>
+    </tr>
+    <tr>
+      <td>WCA Staff</td>
+      <td>
+        <p>An appointed Staff Member of the WCA.</p>
+        <ul>
+          <li>Director</li>
+          <li>Officer</li>
+          <li>Committee/Team Leader</li>
+          <li>Committee/Team Senior Member</li>
+          <li>Committee/Team Member</li>
+          <li>Senior Delegate</li>
+          <li>Regional Delegate</li>
+          <li>Full Delegate</li>
+          <li>Junior Delegate</li>
+        </ul>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/documents/motions/02.2022.1 - Definitions.md
+++ b/documents/motions/02.2022.1 - Definitions.md
@@ -150,7 +150,7 @@ Within WCA we use the following definitions for terminology.
     </tr>
     <tr>
       <td>Registered Speedcuber</td>
-      <td>A person who competed in one or more WCA Competitions. Registered Speedcubers have a personal WCA ID and have the role of Non-voting Member in WCA.</td>
+      <td>A person who has competed in one or more WCA Competitions. Registered Speedcubers have a personal WCA ID and have the role of Non-voting Member in WCA.</td>
     </tr>
     <tr>
       <td>Regulations</td>

--- a/documents/motions/02.2022.1 - Definitions.md
+++ b/documents/motions/02.2022.1 - Definitions.md
@@ -52,7 +52,7 @@ Within WCA we use the following definitions for terminology.
     </tr>
     <tr>
       <td>Community</td>
-      <td>The Community of the WCA as formed by all Staff, Registered Speedcubers, Partners, Spectators, and Users of official WCA online services.</td>
+      <td>The Community of the WCA as formed by all Staff, Registered Speedcubers, Regional Organizations, Partners, Spectators, and Users of official WCA online services.</td>
     </tr>
     <tr>
       <td>Competition Organizer</td>

--- a/documents/motions/02.2022.1 - Definitions.md
+++ b/documents/motions/02.2022.1 - Definitions.md
@@ -80,7 +80,7 @@ Within WCA we use the following definitions for terminology.
     </tr>
     <tr>
       <td>Country</td>
-      <td>Any country, state, territory or a part of territory recognised by the international community, in conformity with the Olympic Charter and the IOC regulations. <br> The Regulations contain the accepted list of countries.</td>
+      <td>Any country, state, territory or a part of territory recognized by the international community, in conformity with the Olympic Charter and the IOC regulations. <br> The Regulations contain the accepted list of countries.</td>
     </tr>
     <tr>
       <td>Event</td>

--- a/documents/motions/02.2024.1 - Definitions.md
+++ b/documents/motions/02.2024.1 - Definitions.md
@@ -4,7 +4,7 @@
 **Subject:** Definitions  
 **Intent:** Define WCA terminology  
 **Submitted by:** WCA Board  
-**Date:** TBC, 2024
+**Date:** August 1, 2024
 
 # Motion
 


### PR DESCRIPTION
Questions to consider:

Are we happy with the definition for event (A particular contest within a WCA Competition). Seems clunky and maybe using “disciplines” could be more descriptive.

Do we want to split off the definition of Regional Organization into Associate and Full or just leave as one for now?

Do we want to add that a Senior Delegate is responsible for managing a group of Regional Delegates as well

Do we need a definition for the WCRP now?
