### PR TITLE
Update 11.2023.1 - Finances

### DIFF
--- a/documents/motions/11.2023.1 - Finances.md
+++ b/documents/motions/11.2023.1 - Finances.md
@@ -11,38 +11,18 @@
 1. The WCA Board shall be accountable for the finances of the WCA.
 2. The WCA Financial Committee shall be responsible for the operations of the finances of the WCA.
 3. The day-to-day management of the Finances of the WCA is handled by the Treasurer.
-4. The WCA Board may delegate, in its supervision of the activities of the WCA, the authority to act in urgent financial matters to the Treasurer as appropriate. In such a case, the WCA Board must be advised at the earliest opportunity of any action that is taken pursuant to such delegated authority.
+4. The WCA Board may delegate, in its supervision of the activities of the WCA, the authority to act in financial matters to individual Staff Members.
 5. The finances shall be conducted by the WCA Board and the WCA Financial Committee in a prudent manner to assure transparent and legal management of the finances, to guarantee the retention of sufficient reserves, and to assure continuation of the activities and programs of the WCA.
 6. Budgeting
    1. The WCA Financial Committee shall deliver to the WCA Board an annual budget proposal, accompanied by a financial forecast for a two-year cycle, which shall have been approved by the WCA Board before the end of January of the budget year.
    2. Every budget year starts on January 1 and ends on December 31.
 7. Annual financial report and accounts
-   1. The WCA Financial Committee will prepare the annual accounts and financial report and deliver to the WCA Board within two months of the end of the last financial year.
-   2. If deemed necessary by the WCA Board, the annual accounts, financial report, and records of the WCA shall be audited by an external accounting firm, which shall be appointed by the WCA Board for a fixed term of four years subject to earlier termination by the WCA Board at any time. The auditors shall be required to deliver a report to the WCA Board on an annual basis in the form of a true and fair audit of the finances of the WCA.
-8. Costs
-   1. Finances of the WCA should be budgeted and available to cover the following categories of costs of the WCA:
-      1. funding of all registrations and procedures for the WCA as a non-profit organization
-      2. funding of the operations of the WCA organization, activities, and online services
-      3. funding of competition equipment
-      4. funding of professionalization of Staff
-      5. funding of the spreading of the WCA to new areas
-      6. covering approved WCA related expenses for Staff and Partners
-      7. funding or sponsoring of selected WCA Competitions
-      8. funding worldwide promotion of the WCA and Speedcubing
-      9. any other cost approved by the WCA Board
+   1. The WCA Financial Committee will prepare or engage an external accounting firm to prepare the annual accounts and financial report and deliver to the WCA Board within four months of the end of the last financial year.
+   2. If deemed necessary by the WCA Board, the annual accounts, financial report, and records of the WCA shall be audited by an external accounting firm, which shall be appointed by the WCA Board. The auditors shall be required to deliver a report to the WCA Board on an annual basis in the form of a true and fair audit of the finances of the WCA.
+   1. Finances of the WCA should be budgeted and available to cover the costs of the WCA:
    2. The WCA may award financial compensation to external individuals or organizations who do approved work for the WCA, e.g. accountancy, legal support, and external advice.
    3. If Financial compensation is necessary, then the WCA Board shall take such actions to approve compensation as may be required by the Nonprofit Integrity Act and other applicable law, and adopt a policy that sets forth guidelines for the determination, review, and approval of the compensation, in accordance with applicable law.
-9. Income
-   1. The WCA may budget and receive incoming funds from the following income sources:
-      1. fees from Registered Speedcubers or Partners
-      2. sponsoring by other parties of the WCA
-      3. sponsoring by other parties of WCA competitions or other WCA activities
-      4. advertising of other parties
-      5. fees for use of the WCA brand or logo
-      6. fees charged by the WCA for activities done by the WCA or WCA Staff for other parties
-      7. gifts, grants, and inheritances
-      8. any other income approved by the WCA Board
-10. Filing
-    1. The WCA Financial Committee shall deliver to the WCA Board the annual returns to be filed, both on a state and federal level, at least 30 days prior to the date they are due to be filed.
-    2. Upon approval of the WCA Board, the WCA Financial Committee shall file any necessary returns on behalf of the WCA.
+9. Filing
+    1. The Treasurer is responsible to ensure that the annual returns to be filed, both on a state and federal level, are prepared, either by the WCA Financial Committee or an external accounting firm, and provided to the WCA Board in advance of the date they are due to be filed
+    2. Upon approval of the WCA Board, the WCA Financial Committee shall ensure any necessary returns are filed on behalf of the WCA, either directly or by engaging an external accounting firm.
     3. The WCA Financial Committee shall publish all returns open to public inspection and an annual financial report on the WCA website.

--- a/documents/motions/11.2023.1 - Finances.md
+++ b/documents/motions/11.2023.1 - Finances.md
@@ -1,10 +1,10 @@
 # SUBMISSION OF PROPOSED MOTION
 
-**Motion number:** 11.2023.1  
+**Motion number:** 11.2024.1  
 **Subject:** Finances of the WCA  
 **Intent:** Description of the Finances of the WCA and specifics in the role of Treasurer  
 **Submitted by:** WCA Board  
-**Date:** April 1, 2023  
+**Date:** TBC, 2024
 
 # Motion
 

--- a/documents/motions/11.2023.1 - Finances.md
+++ b/documents/motions/11.2023.1 - Finances.md
@@ -23,6 +23,6 @@
    2. The WCA may award financial compensation to external individuals or organizations who do approved work for the WCA, e.g. accountancy, legal support, and external advice.
    3. If Financial compensation is necessary, then the WCA Board shall take such actions to approve compensation as may be required by the Nonprofit Integrity Act and other applicable law, and adopt a policy that sets forth guidelines for the determination, review, and approval of the compensation, in accordance with applicable law.
 9. Filing
-    1. The Treasurer is responsible to ensure that the annual returns to be filed, both on a state and federal level, are prepared, either by the WCA Financial Committee or an external accounting firm, and provided to the WCA Board in advance of the date they are due to be filed
+    1. The Treasurer is responsible to ensure that the annual returns to be filed, both on a state and federal level, are prepared, either by the WCA Financial Committee or an external accounting firm, and provided to the WCA Board in advance of the date they are due to be filed.
     2. Upon approval of the WCA Board, the WCA Financial Committee shall ensure any necessary returns are filed on behalf of the WCA, either directly or by engaging an external accounting firm.
     3. The WCA Financial Committee shall publish all returns open to public inspection and an annual financial report on the WCA website.

--- a/documents/motions/11.2024.1 - Finances.md
+++ b/documents/motions/11.2024.1 - Finances.md
@@ -4,7 +4,7 @@
 **Subject:** Finances of the WCA  
 **Intent:** Description of the Finances of the WCA and specifics in the role of Treasurer  
 **Submitted by:** WCA Board  
-**Date:** TBC, 2024
+**Date:** August 1, 2024
 
 # Motion
 


### PR DESCRIPTION
- Expands authority of Board to delegate acting on financial matters to individual Staff Members (in anticipation of Payment Authorization Policy)
- Clarifies WFC can engage external accountants to do work 
- Adds flexibility for how the Board can appoint auditors
- Removes unnecessary detail for Income and Costs - these were superfluous regardless due to the "other approved by the WCA Board". The WFC and Board prefers to use the breakdown of income and costs per the annual Budget approval process, and retain flexibility in how those splits evolve with the WCA.
- Clarifies responsibility for filing of returns (the Treasurer), and adds that this may be delegated to external accountants. 