### PR TITLE
Update 10.2021.2 - Competition Announcement Team

### DIFF
--- a/documents/motions/10.2021.2 - Competition Announcement Team.md
+++ b/documents/motions/10.2021.2 - Competition Announcement Team.md
@@ -1,10 +1,10 @@
 # SUBMISSION OF PROPOSED MOTION
 
-**Motion number:** 10.2021.2  
+**Motion number:** 10.2024.2  
 **Subject:** WCA Competition Announcement Team  
 **Intent:** Rights and duties of the WCA Competition Announcement Team  
 **Submitted by:** WCA Board  
-**Date:** February 28, 2021  
+**Date:** TBC, 2024
 
 # Motion
 

--- a/documents/motions/10.2021.2 - Competition Announcement Team.md
+++ b/documents/motions/10.2021.2 - Competition Announcement Team.md
@@ -20,3 +20,4 @@ The WCA Competition Announcement Team is an Advisory Committee of the WCA.
       1. Editing WCA Competitions data and metadata after they have been announced, at the request of the WCA Delegate(s), the WCA Competition Announcement Team, or the WCA Board.
    3. Deleting WCA Competitions:
       1. Deleting and removing the announcements of WCA Competitions that have been cancelled by the WCA Board or WCAT Leader.
+   4. Additional duties as directed by the WCA Board.

--- a/documents/motions/10.2024.2 - Competition Announcement Team.md
+++ b/documents/motions/10.2024.2 - Competition Announcement Team.md
@@ -4,7 +4,7 @@
 **Subject:** WCA Competition Announcement Team  
 **Intent:** Rights and duties of the WCA Competition Announcement Team  
 **Submitted by:** WCA Board  
-**Date:** TBC, 2024
+**Date:** August 1, 2024
 
 # Motion
 


### PR DESCRIPTION
Updated to add flexibility.

TO DISCUSS for Board: allowing WCAT ability to determine validity of competition results based on the requirements of the WCRP.

My take: No: 
- there are already enough committees which have the power to alter results. 
- WCAT is not the final arbiter of interpretation of alignment with the WCRP (if they were we would also need separate appeals etc), although their expertise may be called upon by the relevant committees. 
- WCAT are primarily responsible for the WCRP and ensuring it is followed for announced competitions, but it shouldn't be their job beyond there. 
- Regulations 1c says that the WCA Delegate must ensure the competition adheres to applicable WCA policies (against my opinion 1c1 was added to explicitly include the WSAP, but the WCRP is still covered by 1c just as the WSAP would be even if 1c1 wasn't added). 
- If there was a policy not followed and/or it wasn't clear that it was followed then article 11 of the regulations cover the appropriate procedures, with disputes about the regulations already handled elsewhere. 
- It would add too much complexity to have WCAT making WCRP decisions on competition validity and ensuring appropriate governance, and thus they should not be making such decisions. Although I'd advice WRC call on WCAT's expertise if they do ever need to make a decision about whether 1c was followed (i.e. if the WCRP was followed) and the appropriate action. 