### PR TITLE
Update 13.2022.1 - Amendments of Motions

### DIFF
--- a/documents/motions/13.2022.1 - Amendments of Motions.md
+++ b/documents/motions/13.2022.1 - Amendments of Motions.md
@@ -24,7 +24,7 @@
       1. All the WCA Members with voting rights at the start of the voting are eligible to vote.
       2. There must be an effective participation strictly above 50% of the total eligible voters for the voting to be considered valid.
       3. If the WCA Voting Members do not approve the Motions, the process will stop.
-      4. The WCA Board may chose to split the approval vote into multile votes for distinct sets of changes. In such a case:
+      4. The WCA Board may chose to split the approval vote into multiple votes for distinct sets of changes. In such a case:
          1. The documents prepared in line with 2.5.2 and 2.5.3 must indicate to which set each change relates, and summarise the changes included in each set.
          2. The clauses 2.7.2 and 2.7.3 apply to each set of changes individually. 
    8. The approved Motions and Amendments of the Motions must be announced and made publicly accessible via the online services of the WCA.

--- a/documents/motions/13.2022.1 - Amendments of Motions.md
+++ b/documents/motions/13.2022.1 - Amendments of Motions.md
@@ -1,10 +1,10 @@
 # SUBMISSION OF PROPOSED MOTION
 
-**Motion number:** 13.2022.1  
+**Motion number:** 13.2024.1  
 **Subject:** Amendments of Motions  
 **Intent:** Definition of the Amendment Procedure of the Motions  
 **Submitted by:** WCA Board  
-**Date:** May 1, 2022  
+**Date:** TBC, 2024
 
 # Motion
 
@@ -24,6 +24,9 @@
       1. All the WCA Members with voting rights at the start of the voting are eligible to vote.
       2. There must be an effective participation strictly above 50% of the total eligible voters for the voting to be considered valid.
       3. If the WCA Voting Members do not approve the Motions, the process will stop.
+      4. The WCA Board may chose to split the approval vote into multile votes for distinct sets of changes. In such a case:
+         1. The documents prepared in line with 2.5.2 and 2.5.3 must indicate to which set each change relates, and summarise the changes included in each set.
+         2. The clauses 2.7.2 and 2.7.3 apply to each set of changes individually. 
    8. The approved Motions and Amendments of the Motions must be announced and made publicly accessible via the online services of the WCA.
    9. The WCA Board shall register the approved Motions with the legal parties.
 3. The Board may vote to approve fixes to clerical errors without the need for a full Motions amendment as outlined above.

--- a/documents/motions/13.2024.1 - Amendments of Motions.md
+++ b/documents/motions/13.2024.1 - Amendments of Motions.md
@@ -4,7 +4,7 @@
 **Subject:** Amendments of Motions  
 **Intent:** Definition of the Amendment Procedure of the Motions  
 **Submitted by:** WCA Board  
-**Date:** TBC, 2024
+**Date:** August 1, 2024
 
 # Motion
 


### PR DESCRIPTION
FOR DISCUSSION BY THE BOARD:

- One of the criticisms of past motions updates is that voting members can only vote yes/no on the motions as a set.
- While I don't think it is practical to have voting members vote on each change line by line (especially as this would not produce a coherent result if there were a mixture of approvals/not) it would make sense to bundle the approvals into several "sets" or "themes". 
- I didn't want to be too prescriptive on the groupings. There will be some motions changes where they are all inter-related (either in practice, or thematically) and so need to have a vote on them as a single package. While at other times there could be 3-4 key themes that could be voted on separately (similar to how this update is shaping up).
- I chose not to change the procedure for how the Board itself makes the proposal (I don't think adding detail there would be helpful). 