### PR TITLE
Update 22.2022.1 - Major Championship Selection

### DIFF
--- a/documents/motions/22.2022.1 - Major Championship Selection.md
+++ b/documents/motions/22.2022.1 - Major Championship Selection.md
@@ -1,29 +1,27 @@
 # SUBMISSION OF PROPOSED MOTION
 
-**Motion number:** 22.2022.1  
+**Motion number:** 22.2024.1  
 **Subject:** Major Championship Selection  
 **Intent:** Define the WCA Major Championship selection process  
 **Submitted by:** WCA Board  
-**Date:** May 1, 2022  
+**Date:** TBC, 2024
 
 # Motion
 
-Major Championship host cities are selected via a bidding procedure that is initiated and led by the Board of Directors. 
+Major Championship host cities are selected via a bidding procedure that is initiated by the WCA Board and let by the WCA Major Championship Team. 
 
 1. Major Championship events include WCA Continental Championships and the WCA World Championships.
    1. WCA Continental Championships shall be held in even numbered years.
    2. WCA World Championship shall be held in odd numbered years.
-2. At the start of the bidding procedure the WCA Board will announce which Championships are available for bidding, along with a deadline for applicants to submit bid documents.
+2. At the start of the bidding procedure the WCA Major Championship Team will announce which Championships are available for bidding, along with a deadline for applicants to submit bid documents and topics which bid documents must address.
+   1. The WCA Major Championship Team may chose to hold an expression of interest period prior to the formal bidding procedure.
 3. Applications must be made by a WCA Regional Organization.
-4. Applications for Major Championship events must address the following topics in relation to the competition:
-   1. Location
-   2. Dates
-   3. Organizational Team
-   4. Finances
-5. Once applications are closed the WCA Board will assemble a selection committee.
+4. Once applications are closed the WCA Board will appoint a selection committee based on the recommendation of the WCA Major Championship Team.
    1. The selection committee must have at least 5 members.
-   2. All Directors who are not involved in an application for a Major Championship will be members of the selection committee.
-   3. The WCA Board will ask for volunteers from WCA Leaders and Senior Delegates to fill the remaining slots on the selection committee.
-6. Once a selection committee is formed they will determine which applicants will proceed to an interview. The selection committee will conduct interviews with application teams to gain a better understanding of the proposed event.
-7. Once the selection committee has conducted interviews with the application teams they will vote to select a host city.
-8. In the case that no applications are selected the WCA Board may open another application period at a later date.
+   2. The selection committee must have at least: one Director, one member of the WCA Major Championship Team, and one volunteer from WCA Leaders and Senior Delegates.
+   3. Members of the selection committee must not be involved in an application for the Major Championship.
+5. Once a selection committee is formed they will determine which applicants will proceed to an interview.
+   1. This determination may be informed by information gathered through the expression of interest period (if held), the bid document itself, and other factors.
+   2. The selection committee will conduct interviews with application teams to gain a better understanding of the proposed event.
+6. Once the selection committee has conducted interviews with the application teams they will vote to select a host city.
+7. In the case that no applications are selected the WCA Board may open another application period at a later date.

--- a/documents/motions/22.2022.1 - Major Championship Selection.md
+++ b/documents/motions/22.2022.1 - Major Championship Selection.md
@@ -14,7 +14,7 @@ Major Championship host cities are selected via a bidding procedure that is init
    1. WCA Continental Championships shall be held in even numbered years.
    2. WCA World Championship shall be held in odd numbered years.
 2. At the start of the bidding procedure the WCA Major Championship Team will announce which Championships are available for bidding, along with a deadline for applicants to submit bid documents and topics which bid documents must address.
-   1. The WCA Major Championship Team may chose to hold an expression of interest period prior to the formal bidding procedure.
+   1. The WCA Major Championship Team may choose to hold an expression of interest period prior to the formal bidding procedure.
 3. Applications must be made by a WCA Regional Organization.
 4. Once applications are closed the WCA Board will appoint a selection committee based on the recommendation of the WCA Major Championship Team.
    1. The selection committee must have at least 5 members.

--- a/documents/motions/22.2022.1 - Major Championship Selection.md
+++ b/documents/motions/22.2022.1 - Major Championship Selection.md
@@ -18,7 +18,7 @@ Major Championship host cities are selected via a bidding procedure that is init
 3. Applications must be made by a WCA Regional Organization.
 4. Once applications are closed the WCA Board will appoint a selection committee based on the recommendation of the WCA Major Championship Team.
    1. The selection committee must have at least 5 members.
-   2. The selection committee must have at least: one Director, one member of the WCA Major Championship Team, and one volunteer from WCA Leaders and Senior Delegates.
+   2. The selection committee must have at least: one Director, one representative from the WCA Major Championship Team, and one volunteer from WCA Leaders and Senior Delegates.
    3. Members of the selection committee must not be involved in an application for the Major Championship.
 5. Once a selection committee is formed they will determine which applicants will proceed to an interview.
    1. This determination may be informed by information gathered through the expression of interest period (if held), the bid document itself, and other factors.

--- a/documents/motions/22.2022.1 - Major Championship Selection.md
+++ b/documents/motions/22.2022.1 - Major Championship Selection.md
@@ -21,7 +21,7 @@ Major Championship host cities are selected via a bidding procedure that is init
    2. The selection committee must have at least: one Director, one representative from the WCA Major Championship Team, and one volunteer from WCA Leaders and Senior Delegates.
    3. Members of the selection committee must not be involved in an application for the Major Championship.
 5. Once a selection committee is formed they will determine which applicants will proceed to an interview.
-   1. This determination may be informed by information gathered through the expression of interest period (if held), the bid document itself, and other factors.
+   1. This determination may be informed by information gathered through the expression of interest period (if held), the bid document, and other factors at the discretion of the selection committee.
    2. The selection committee will conduct interviews with application teams to gain a better understanding of the proposed event.
 6. Once the selection committee has conducted interviews with the application teams they will vote to select a host city.
-7. In the case that no applications are selected the WCA Board may open another application period at a later date.
+7. In the case that no applications are selected the WCA Board may initiate another application period at a later date.

--- a/documents/motions/22.2022.1 - Major Championship Selection.md
+++ b/documents/motions/22.2022.1 - Major Championship Selection.md
@@ -8,7 +8,7 @@
 
 # Motion
 
-Major Championship host cities are selected via a bidding procedure that is initiated by the WCA Board and let by the WCA Major Championship Team. 
+Major Championship host cities are selected via a bidding procedure that is initiated by the WCA Board and led by the WCA Major Championship Team. 
 
 1. Major Championship events include WCA Continental Championships and the WCA World Championships.
    1. WCA Continental Championships shall be held in even numbered years.

--- a/documents/motions/22.2024.1 - Major Championship Selection.md
+++ b/documents/motions/22.2024.1 - Major Championship Selection.md
@@ -4,7 +4,7 @@
 **Subject:** Major Championship Selection  
 **Intent:** Define the WCA Major Championship selection process  
 **Submitted by:** WCA Board  
-**Date:** TBC, 2024
+**Date:** August 1, 2024
 
 # Motion
 


### PR DESCRIPTION
- Board of Directors -> WCA Board
- Change bidding to be initiated by Board but led by the WMCT
- Removes specifics on what bid documents must address - this would be included in the announcement (flexibility)
- Changes selection committee: still appointed by the Board, but does not contain all Board members by default and has a representative of the WMCT and at least one Senior/Leader. At least one Board member still required. 
- Gives scope for an expression of interest period prior to the formal bidding period.
- NOTE: initially before the WMCT is fully set up it would be led by the WCA Board, so there wouldn't be a major difference to the current process until the team is established. 